### PR TITLE
Get `NativeModules` from `react-native`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 /* @flow */
 
-const Mailer = require('NativeModules').RNMail;
+const Mailer = require('react-native').NativeModules.RNMail;
 export default Mailer;
-


### PR DESCRIPTION
Otherwise packager seems to throw an error about not finding `NativeModules` in production mode